### PR TITLE
fix(cli): add DEEPGRAM_API_KEY to env validation

### DIFF
--- a/call_use/cli.py
+++ b/call_use/cli.py
@@ -18,7 +18,8 @@ def _check_env():
         "LIVEKIT_API_KEY": "LiveKit API key",
         "LIVEKIT_API_SECRET": "LiveKit API secret",
         "SIP_TRUNK_ID": "Twilio SIP trunk ID in LiveKit",
-        "OPENAI_API_KEY": "OpenAI API key (for STT + LLM + TTS)",
+        "OPENAI_API_KEY": "OpenAI API key (for LLM reasoning and text-to-speech)",
+        "DEEPGRAM_API_KEY": "Deepgram API key (for speech-to-text)",
     }
     missing = [f"  {k} — {v}" for k, v in required.items() if not os.environ.get(k)]
     if missing:

--- a/tests/test_agent_bdd.py
+++ b/tests/test_agent_bdd.py
@@ -689,6 +689,7 @@ class TestCLIBehavior:
             msg = str(exc_info.value)
             assert "LIVEKIT_URL" in msg
             assert "LIVEKIT_API_KEY" in msg
+            assert "DEEPGRAM_API_KEY" in msg
             assert "https://github.com/agent-next/call-use#configure" in msg
 
     def test_invalid_json_user_info_exits_2(self):
@@ -821,6 +822,7 @@ class TestMCPBehavior:
             "LIVEKIT_API_SECRET": "secret",
             "SIP_TRUNK_ID": "trunk",
             "OPENAI_API_KEY": "sk-test",
+            "DEEPGRAM_API_KEY": "dg-test",
         },
     )
     @patch("call_use.mcp_server.LiveKitAPI")

--- a/tests/test_bdd_scenarios.py
+++ b/tests/test_bdd_scenarios.py
@@ -23,6 +23,7 @@ _FULL_ENV = {
     "LIVEKIT_API_SECRET": "secret",
     "SIP_TRUNK_ID": "trunk",
     "OPENAI_API_KEY": "sk-test",
+    "DEEPGRAM_API_KEY": "dg-test",
 }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -221,6 +221,7 @@ def test_check_env_raises_on_missing_vars():
         msg = str(e)
         assert "LIVEKIT_URL" in msg
         assert "OPENAI_API_KEY" in msg
+        assert "DEEPGRAM_API_KEY" in msg
         assert "https://github.com/agent-next/call-use#configure" in msg
 
 
@@ -232,6 +233,7 @@ def test_check_env_raises_on_missing_vars():
         "LIVEKIT_API_SECRET": "secret",
         "SIP_TRUNK_ID": "trunk",
         "OPENAI_API_KEY": "sk-test",
+        "DEEPGRAM_API_KEY": "dg-test",
     },
 )
 def test_check_env_passes_when_all_set():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16,6 +16,7 @@ _FULL_ENV = {
     "LIVEKIT_API_SECRET": "secret",
     "SIP_TRUNK_ID": "trunk",
     "OPENAI_API_KEY": "sk-test",
+    "DEEPGRAM_API_KEY": "dg-test",
 }
 
 

--- a/tests/test_user_journeys.py
+++ b/tests/test_user_journeys.py
@@ -415,6 +415,7 @@ class TestMCPUserExperience:
                     "LIVEKIT_API_SECRET": "s",
                     "SIP_TRUNK_ID": "ST_test",
                     "OPENAI_API_KEY": "sk-test",
+                    "DEEPGRAM_API_KEY": "dg-test",
                 },
             ):
                 result = await _do_dial(phone="+12025551234", instructions="test")


### PR DESCRIPTION
## Summary
- Add `DEEPGRAM_API_KEY` to `_check_env()` required env vars — the agent uses Deepgram STT but this key was not validated
- Fix `OPENAI_API_KEY` description from "for STT + LLM + TTS" to "for LLM reasoning and text-to-speech" (STT is Deepgram, not OpenAI)
- Update 5 test files to include `DEEPGRAM_API_KEY` in env fixtures

Closes #17

## Test plan
- [x] All 383 tests pass
- [x] `_check_env()` now validates 6 env vars including DEEPGRAM_API_KEY
- [x] Missing DEEPGRAM_API_KEY produces clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)