### PR TITLE
fix(agent): move approval cleanup inside _cmd_lock to prevent race

### DIFF
--- a/call_use/agent.py
+++ b/call_use/agent.py
@@ -447,9 +447,9 @@ class _LiveKitCallAgent(Agent):
                     self.session.output.set_audio_enabled(True)
                     self.session.input.set_audio_enabled(True)
                     await self._update_metadata("connected")
-            self._approval_event = None
-            self._approval_result = None
-            self._approval_id = None
+                self._approval_event = None
+                self._approval_result = None
+                self._approval_id = None
 
     # ---- Hang-up tool ----
 


### PR DESCRIPTION
## Summary
- Move `_approval_event`, `_approval_result`, `_approval_id` cleanup from outside `_cmd_lock` to inside it in `_request_user_approval_impl` finally block
- Prevents a race where a concurrent second approval request could have its event overwritten by the first request's cleanup

Closes #21

## Test plan
- [x] All 383 tests pass
- [x] Cleanup now happens atomically under `_cmd_lock`
- [x] Existing approval flow tests (approve, reject, timeout, takeover-during-approval) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)